### PR TITLE
Switch to weekly posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # TagPro Leaderboards
 
-TagPro Leaderboards is a script for retrieving leaderboard statistics from the online game TagPro, and posting those stats to the TagPro subreddit. It is intended to be run as a cronjob, or scheduled on a service such as [AWS Lambda](https://aws.amazon.com/lambda/).
+TagPro Leaderboards is a script for retrieving leaderboard statistics from the online game TagPro, and posting those stats to the TagPro subreddit. It is intended to be run on [AWS Lambda](https://aws.amazon.com/lambda/).
 
 ## Configuration
+
+### Reddit
 
 1. [Register a Reddit application.](https://github.com/reddit/reddit/wiki/OAuth2#getting-started) You should use the "script" classification.
 
@@ -15,7 +17,31 @@ client_id = "YOUR_CLIENT_ID"
 client_secret = "YOUR_CLIENT_SECRET"
 reddit_username = "YOUR_REDDIT_USERNAME"
 reddit_password = "YOUR_REDDIT_PASSWORD"
+dynamodb_name = "YOUR_DYNAMODB_TABLE_NAME"
+dynamodb_region = "YOUR_DYNAMODB_TABLE_REGION"
 ```
+
+### AWS
+
+From the [AWS Console](https://aws.amazon.com/console/):
+
+1. Create a Lambda function.
+    * Choose Python 3.7 as the runtime.
+    * Upload the project directory as the source. The entrypoint is `leaderboards.py`.
+    * \>= 512MB memory allocation is preferred for quick execution.
+2. Create 3 CloudWatch rules.
+    * Set a "Schedule" pattern with Cron expression:
+        * daily: `59 19 * * ? *`
+        * weekly: `59 19 ? * 1 *`
+        * monthly: `59 19 1 * ? *`
+    * Set the target as the lambda function.
+    * As input to the function, add JSON text `{"board_name":"<value>"}` where `value` is day/week/month.
+3. Create a DynamoDB table.
+    * The partition key is a string called `timestamp`.
+    * The sort key is a string called `type`.
+    * Ensure the role for the Lambda function has the ability to read/write this table.
+
+The Lambda console lets you test execute the script. Make use of it!
 
 ## Usage
 
@@ -23,10 +49,6 @@ The script requires an argument containing the name of the board to retrieve:
 
 `leaderboards.py <day/week/month>`
 
-The script is intended to be run as a cronjob/equivalent, and run separately even if boards are resetting simultaneously. This is an example crontab for starting 5 minutes before the boards are scheduled to reset (based on UTC):
+Alternatively, it can be run with the `board_name` environment variable set to one of the above values.
 
-```text
-55 19 * * * /path/to/leaderboards.py day
-55 19 * * 0 /path/to/leaderboards.py week
-55 19 1 * * /path/to/leaderboards.py month
-```
+The script is intended to be executed separately even if boards are resetting simultaneously. For example, it is run three times on a day where both a weekly and monthly board reset (since the daily board resets every day).

--- a/helpers.py
+++ b/helpers.py
@@ -14,7 +14,7 @@ def submission_title(board_name):
     cur_time = datetime.utcnow()
 
     if board_name == "day":
-        date_string = cur_time.strftime('%B %d, %Y')
+        date_string = cur_time.strftime('%A, %B %d, %Y')
     elif board_name == "week":
         date_string = cur_time.strftime('%B %d, %Y')
     elif board_name == "month":

--- a/helpers.py
+++ b/helpers.py
@@ -10,17 +10,15 @@ name_associations = {
 }
 
 
-def submission_title(board_name):
-    cur_time = datetime.utcnow()
-
+def submission_title(date, board_name):
     if board_name == "day":
-        date_string = cur_time.strftime('%A, %B %d, %Y')
+        date_string = date.strftime('%A, %B %d, %Y')
     elif board_name == "week":
-        date_string = cur_time.strftime('%B %d, %Y')
+        date_string = date.strftime('%B %d, %Y')
     elif board_name == "month":
         # monthly boards are reset during the 1st, so we need the name of the
         # previous month
-        prev_time = cur_time - relativedelta(months=1)
+        prev_time = date - relativedelta(months=1)
         date_string = prev_time.strftime('%B %Y')
     else:
         raise ValueError("Invalid board name argument; valid names are "

--- a/helpers.py
+++ b/helpers.py
@@ -36,4 +36,4 @@ def time_str(seconds):
     # https://stackoverflow.com/a/8907407
     hours, remainder = divmod(int(seconds), 60 * 60)
     minutes, seconds = divmod(remainder, 60)
-    return "%d:%d:%d" % (hours, minutes, seconds)
+    return "%02d:%02d:%02d" % (hours, minutes, seconds)

--- a/leaderboards.py
+++ b/leaderboards.py
@@ -140,13 +140,14 @@ cur_date = datetime.utcnow().date()
 dynamodb = boto3.resource('dynamodb', region_name=secret.dynamodb_region)
 table = dynamodb.Table(secret.dynamodb_name)
 
-if board_name == "day":
-    # save to database
-    response = table.put_item(Item={
-        'text': post_text,
-        'timestamp': cur_date.isoformat()
-    })
-elif board_name == "week":
+# regardless of the type of board, we save it in the database
+response = table.put_item(Item={
+    'text': post_text,
+    'timestamp': cur_date.isoformat(),
+    'type': board_name
+})
+
+if board_name == "week":
     # create post with weekly info, then create comments for days
     submission = subreddit.submit(
         helpers.submission_title(cur_date, board_name), post_text)
@@ -154,7 +155,8 @@ elif board_name == "week":
         date = cur_date - relativedelta(days=i)
         try:
             response = table.get_item(Key={
-                'timestamp': date.isoformat()
+                'timestamp': date.isoformat(),
+                'type': 'day'
             })
         except ClientError as e:
             print(e.response['Error']['Message'])

--- a/leaderboards.py
+++ b/leaderboards.py
@@ -137,8 +137,8 @@ for profile in profiles:
     rank += 1
 
 cur_date = datetime.utcnow().date()
-dynamodb = boto3.resource('dynamodb', region_name='us-east-2')
-table = dynamodb.Table('tagpro-leaderboards')
+dynamodb = boto3.resource('dynamodb', region_name=secret.dynamodb_region)
+table = dynamodb.Table(secret.dynamodb_name)
 
 if board_name == "day":
     # save to database


### PR DESCRIPTION
The bot no longer creates a new post for each daily board reset, and instead adds the daily boards as comments in each weekly thread.